### PR TITLE
fix: Update badge link in README to correct template owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ In this course, you will explore:
 }).toString()
 -->
 
-[![](https://img.shields.io/badge/Copy%20Exercise-%E2%86%92-1f883d?style=for-the-badge&logo=github&labelColor=197935)](https://github.com/new?template_owner=skills&template_name=secure-repository-supply-chain&owner=%40me&name=skills-secure-repository-supply-chain&description=Exercise:+Secure+your+Repository+Supply+Chain&visibility=public)
+[![](https://img.shields.io/badge/Copy%20Exercise-%E2%86%92-1f883d?style=for-the-badge&logo=github&labelColor=197935)](https://github.com/new?template_owner=arilivigni&template_name=secure-repository-supply-chain&owner=%40me&name=skills-secure-repository-supply-chain&description=Exercise:+Secure+your+Repository+Supply+Chain&visibility=public)
 
 <details>
 <summary>Having trouble? 🤷</summary><br/>


### PR DESCRIPTION
This pull request includes a minor update to the `README.md` file to fix a link. The change updates the `template_owner` parameter in the "Copy Exercise" badge link to point to the correct repository owner.