### PR TITLE
fix: Update permissions and workflow versions in GitHub Actions

### DIFF
--- a/.github/workflows/0-start-exercise.yml
+++ b/.github/workflows/0-start-exercise.yml
@@ -7,9 +7,9 @@ on:
       - main
 
 permissions:
-  contents: write
-  actions: write
-  issues: write
+  contents: write # Update Readme
+  actions: write # Disable/enable workflows
+  issues: write # Create issue and comment on issues
 
 env:
   STEP_1_FILE: ".github/steps/1-dependency-graph.md"

--- a/.github/workflows/1-dependency-graph.yml
+++ b/.github/workflows/1-dependency-graph.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   find_exercise:
     name: Find Exercise Issue
-    uses: skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml@v0.1.0
+    uses: skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml@v0.3.0
 
   check_step_work:
     name: Check step work

--- a/.github/workflows/2-dependabot-alerts.yml
+++ b/.github/workflows/2-dependabot-alerts.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   find_exercise:
     name: Find Exercise Issue
-    uses: skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml@v0.1.0
+    uses: skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml@v0.3.0
 
   check_step_work:
     name: Check step work

--- a/.github/workflows/3-dependabot-security.yml
+++ b/.github/workflows/3-dependabot-security.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   find_exercise:
     name: Find Exercise Issue
-    uses: skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml@v0.1.0
+    uses: skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml@v0.3.0
 
   check_step_work:
     name: Check step work

--- a/.github/workflows/4-dependabot-versions.yml
+++ b/.github/workflows/4-dependabot-versions.yml
@@ -8,7 +8,7 @@ on:
       - ".github/dependabot.yml"
 
 permissions:
-  contents: read
+  contents: write
   actions: write
   issues: write
 
@@ -18,7 +18,7 @@ env:
 jobs:
   find_exercise:
     name: Find Exercise Issue
-    uses: skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml@v0.1.0
+    uses: skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml@v0.3.0
 
   check_step_work:
     name: Check step work


### PR DESCRIPTION
This pull request updates several GitHub Actions workflows to improve functionality and maintain consistency. Key changes include updating permissions for better documentation, upgrading the `find-exercise-issue.yml` workflow version across multiple files, and modifying specific permissions to align with workflow requirements.

### Workflow Permission Updates:
* Updated comments in the `permissions` section of `.github/workflows/0-start-exercise.yml` to clarify the purpose of each permission.
* Changed `contents` permission from `read` to `write` in `.github/workflows/4-dependabot-versions.yml` to allow writing operations.

### Workflow Dependency Updates:
* Upgraded `skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml` from `v0.1.0` to `v0.3.0` in the following workflows:
  - `.github/workflows/1-dependency-graph.yml`
  - `.github/workflows/2-dependabot-alerts.yml`
  - `.github/workflows/3-dependabot-security.yml`
  - `.github/workflows/4-dependabot-versions.yml`