### PR TITLE
fix: Remove unused steps from dependency graph workflows

### DIFF
--- a/.github/workflows/1-dependency-graph.yml
+++ b/.github/workflows/1-dependency-graph.yml
@@ -69,23 +69,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # END: Check practical exercise
-  
-      - name: Build message - step finished
-        id: build-message-step-finish
-        uses: skills/action-text-variables@v1
-        with:
-          template-file: skills-response-templates/step-feedback/step-finished-prepare-next-step.md
-          template-vars: |
-            next_step_number=2
-
-      - name: Update comment - step finished
-        run: |
-          gh issue comment "$ISSUE_URL" \
-            --body "$ISSUE_BODY" \
-            --edit-last
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ISSUE_BODY: ${{ steps.build-message-step-finish.outputs.updated-text }}
 
   post_next_step_content:
     name: Post next step content

--- a/.github/workflows/2-dependabot-alerts.yml
+++ b/.github/workflows/2-dependabot-alerts.yml
@@ -106,22 +106,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # END: Check practical exercise
-
-      - name: Build message - step finished
-        id: build-message-step-finish
-        uses: skills/action-text-variables@v1
-        with:
-          template-file: exercise-toolkit/markdown-templates/step-feedback/step-finished-prepare-next-step.md
-          template-vars: |
-            next_step_number=3
-
-      - name: Update comment - step finished
-        run: |
-          gh issue comment "$ISSUE_URL" \
-            --body "${{ steps.build-message-step-finish.outputs.updated-text }}" \
-            --edit-last
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   
   post_next_step_content:
     name: Post next step content

--- a/.github/workflows/3-dependabot-security.yml
+++ b/.github/workflows/3-dependabot-security.yml
@@ -108,22 +108,6 @@ jobs:
 
       # END: Check practical exercise
 
-      - name: Build message - step finished
-        id: build-message-step-finish
-        uses: skills/action-text-variables@v1
-        with:
-          template-file: skills-response-templates/step-feedback/step-finished-prepare-next-step.md
-          template-vars: |
-            next_step_number=4
-
-      - name: Update comment - step finished
-        run: |
-          gh issue comment "$ISSUE_URL" \
-            --body "$ISSUE_BODY" \
-            --edit-last
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ISSUE_BODY: ${{ steps.build-message-step-finish.outputs.updated-text }}
   
   post_next_step_content:
     name: Post next step content

--- a/.github/workflows/4-dependabot-versions.yml
+++ b/.github/workflows/4-dependabot-versions.yml
@@ -30,22 +30,12 @@ jobs:
       ISSUE_URL: ${{ needs.find_exercise.outputs.issue-url }}
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
       - name: Get response templates
         uses: actions/checkout@v4
         with:
-          repository: skills/response-templates
-          path: skills-response-templates
-
-      - name: Update comment - checking work
-        run: |
-          gh issue comment "$ISSUE_URL" \
-            --body-file skills-response-templates/step-feedback/checking-work.md \
-            --edit-last
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          repository: skills/exercise-toolkit
+          path: exercise-toolkit
+          ref: v0.3.0
 
       # START: Check practical exercise
 


### PR DESCRIPTION
This pull request simplifies and standardizes the GitHub Actions workflows by removing redundant steps and updating references to a new repository for response templates. The most important changes involve cleaning up unnecessary steps for updating comments and switching the repository used for templates.

### Workflow Simplifications:
* Removed the "Build message - step finished" and "Update comment - step finished" steps from the workflows `1-dependency-graph.yml`, `2-dependabot-alerts.yml`, and `3-dependabot-security.yml`. These steps were responsible for preparing and posting step-completion messages, which are no longer needed. [[1]](diffhunk://#diff-3b9840fdcb10141265ad5b2ce3dd2e6a0ce2c94734e7e9a5a7ff30b08fdc38ebL73-L89) [[2]](diffhunk://#diff-3d6eb05dcd159c5d64fd2d4f16476a8ce26375d599053cc6a43b820d7e5f52e9L110-L125) [[3]](diffhunk://#diff-759c4650bcead7f317c8569624e44e74a8169a301cccbad43555c1eb5686d293L111-L126)

### Repository Update:
* In `4-dependabot-versions.yml`, replaced the `skills/response-templates` repository with `skills/exercise-toolkit` for response templates and updated the reference to version `v0.3.0`. This ensures the workflow uses the latest toolkit for managing templates.