### PR TITLE
fix: Update step finished message templates in workflow files

### DIFF
--- a/.github/workflows/1-dependency-graph.yml
+++ b/.github/workflows/1-dependency-graph.yml
@@ -74,18 +74,17 @@ jobs:
         id: build-message-step-finish
         uses: skills/action-text-variables@v1
         with:
-          template-file: skills-response-templates/step-feedback/step-finished-prepare-next-step.md
+          template-file: exercise-toolkit/markdown-templates/step-feedback/step-finished-prepare-next-step.md
           template-vars: |
             next_step_number=3
 
       - name: Update comment - step finished
         run: |
           gh issue comment "$ISSUE_URL" \
-            --body "$ISSUE_BODY" \
+            --body "${{ steps.build-message-step-finish.outputs.updated-text }}" \
             --edit-last
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ISSUE_BODY: ${{ steps.build-message-step-finish.outputs.updated-text }}
         
   post_next_step_content:
     name: Post next step content

--- a/.github/workflows/2-dependabot-alerts.yml
+++ b/.github/workflows/2-dependabot-alerts.yml
@@ -111,18 +111,17 @@ jobs:
         id: build-message-step-finish
         uses: skills/action-text-variables@v1
         with:
-          template-file: skills-response-templates/step-feedback/step-finished-prepare-next-step.md
+          template-file: exercise-toolkit/markdown-templates/step-feedback/step-finished-prepare-next-step.md
           template-vars: |
             next_step_number=3
 
       - name: Update comment - step finished
         run: |
           gh issue comment "$ISSUE_URL" \
-            --body "$ISSUE_BODY" \
+            --body "${{ steps.build-message-step-finish.outputs.updated-text }}" \
             --edit-last
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ISSUE_BODY: ${{ steps.build-message-step-finish.outputs.updated-text }}
           
   post_next_step_content:
     name: Post next step content

--- a/.github/workflows/3-dependabot-security.yml
+++ b/.github/workflows/3-dependabot-security.yml
@@ -112,18 +112,17 @@ jobs:
         id: build-message-step-finish
         uses: skills/action-text-variables@v1
         with:
-          template-file: skills-response-templates/step-feedback/step-finished-prepare-next-step.md
+          template-file: exercise-toolkit/markdown-templates/step-feedback/step-finished-prepare-next-step.md
           template-vars: |
             next_step_number=3
 
       - name: Update comment - step finished
         run: |
           gh issue comment "$ISSUE_URL" \
-            --body "$ISSUE_BODY" \
+            --body "${{ steps.build-message-step-finish.outputs.updated-text }}" \
             --edit-last
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ISSUE_BODY: ${{ steps.build-message-step-finish.outputs.updated-text }}
 
   post_next_step_content:
     name: Post next step content


### PR DESCRIPTION
This pull request updates workflow files to improve template management and streamline the handling of issue comments. The changes ensure consistency in template file paths and simplify the usage of output variables for comment updates.

Template file path updates:

* Updated the `template-file` path from `skills-response-templates/step-feedback/step-finished-prepare-next-step.md` to `exercise-toolkit/markdown-templates/step-feedback/step-finished-prepare-next-step.md` across the following workflow files: `.github/workflows/1-dependency-graph.yml` [[1]](diffhunk://#diff-3b9840fdcb10141265ad5b2ce3dd2e6a0ce2c94734e7e9a5a7ff30b08fdc38ebL77-L88) `.github/workflows/2-dependabot-alerts.yml` [[2]](diffhunk://#diff-3d6eb05dcd159c5d64fd2d4f16476a8ce26375d599053cc6a43b820d7e5f52e9L114-L125) and `.github/workflows/3-dependabot-security.yml` [[3]](diffhunk://#diff-759c4650bcead7f317c8569624e44e74a8169a301cccbad43555c1eb5686d293L115-L126).

Environment variable cleanup:

* Replaced the use of the `ISSUE_BODY` environment variable with direct usage of `${{ steps.build-message-step-finish.outputs.updated-text }}` for the `--body` parameter in the `gh issue comment` command in the same workflow files: `.github/workflows/1-dependency-graph.yml` [[1]](diffhunk://#diff-3b9840fdcb10141265ad5b2ce3dd2e6a0ce2c94734e7e9a5a7ff30b08fdc38ebL77-L88) `.github/workflows/2-dependabot-alerts.yml` [[2]](diffhunk://#diff-3d6eb05dcd159c5d64fd2d4f16476a8ce26375d599053cc6a43b820d7e5f52e9L114-L125) and `.github/workflows/3-dependabot-security.yml` [[3]](diffhunk://#diff-759c4650bcead7f317c8569624e44e74a8169a301cccbad43555c1eb5686d293L115-L126).