### PR TITLE
fix: update condition to skip first run for check step work jobs

### DIFF
--- a/.github/workflows/1-dependency-graph.yml
+++ b/.github/workflows/1-dependency-graph.yml
@@ -26,7 +26,8 @@ jobs:
     name: Check step work
     runs-on: ubuntu-latest
     needs: find_exercise
-    if: !github.event.repository.is_template
+    if: |
+      !github.event.repository.is_template && github.run_number != 1
     env:
       ISSUE_URL: ${{ needs.find_exercise.outputs.issue-url }}
 

--- a/.github/workflows/2-dependabot-alerts.yml
+++ b/.github/workflows/2-dependabot-alerts.yml
@@ -26,7 +26,8 @@ jobs:
     name: Check step work
     runs-on: ubuntu-latest
     needs: find_exercise
-    if: !github.event.repository.is_template
+    if: |
+      !github.event.repository.is_template && github.run_number != 1
     env:
       ISSUE_URL: ${{ needs.find_exercise.outputs.issue-url }}
 

--- a/.github/workflows/3-dependabot-security.yml
+++ b/.github/workflows/3-dependabot-security.yml
@@ -26,7 +26,8 @@ jobs:
     name: Check step work
     runs-on: ubuntu-latest
     needs: find_exercise
-    if: !github.event.repository.is_template
+    if: |
+      !github.event.repository.is_template && github.run_number != 1
     env:
       ISSUE_URL: ${{ needs.find_exercise.outputs.issue-url }}
 

--- a/.github/workflows/4-dependabot-versions.yml
+++ b/.github/workflows/4-dependabot-versions.yml
@@ -26,7 +26,8 @@ jobs:
     name: Check step work
     needs: find_exercise
     runs-on: ubuntu-latest
-    if: !github.event.repository.is_template
+    if: |
+      !github.event.repository.is_template && github.run_number != 1
     env:
       ISSUE_URL: ${{ needs.find_exercise.outputs.issue-url }}
 


### PR DESCRIPTION
This pull request updates multiple GitHub Actions workflows to include an additional condition for job execution. Specifically, it ensures that jobs only run if the repository is not a template and the current run is not the first run (`github.run_number != 1`).