### PR TITLE
fix: update conditions to skip first run for dependency graph jobs

### DIFF
--- a/.github/workflows/1-dependency-graph.yml
+++ b/.github/workflows/1-dependency-graph.yml
@@ -21,13 +21,15 @@ jobs:
   find_exercise:
     name: Find Exercise Issue
     uses: skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml@v0.3.0
+    if: |
+      github.run_number != 1
 
   check_step_work:
     name: Check step work
     runs-on: ubuntu-latest
     needs: find_exercise
     if: |
-      !github.event.repository.is_template && github.run_number != 1
+      !github.event.repository.is_template
     env:
       ISSUE_URL: ${{ needs.find_exercise.outputs.issue-url }}
 

--- a/.github/workflows/2-dependabot-alerts.yml
+++ b/.github/workflows/2-dependabot-alerts.yml
@@ -21,13 +21,15 @@ jobs:
   find_exercise:
     name: Find Exercise Issue
     uses: skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml@v0.3.0
+    if: |
+      github.run_number != 1
 
   check_step_work:
     name: Check step work
     runs-on: ubuntu-latest
     needs: find_exercise
     if: |
-      !github.event.repository.is_template && github.run_number != 1
+      !github.event.repository.is_template
     env:
       ISSUE_URL: ${{ needs.find_exercise.outputs.issue-url }}
 

--- a/.github/workflows/3-dependabot-security.yml
+++ b/.github/workflows/3-dependabot-security.yml
@@ -21,13 +21,15 @@ jobs:
   find_exercise:
     name: Find Exercise Issue
     uses: skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml@v0.3.0
+    if: |
+      github.run_number != 1
 
   check_step_work:
     name: Check step work
     runs-on: ubuntu-latest
     needs: find_exercise
     if: |
-      !github.event.repository.is_template && github.run_number != 1
+      !github.event.repository.is_template
     env:
       ISSUE_URL: ${{ needs.find_exercise.outputs.issue-url }}
 

--- a/.github/workflows/4-dependabot-versions.yml
+++ b/.github/workflows/4-dependabot-versions.yml
@@ -21,13 +21,15 @@ jobs:
   find_exercise:
     name: Find Exercise Issue
     uses: skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml@v0.3.0
+    if: |
+      github.run_number != 1
 
   check_step_work:
     name: Check step work
     needs: find_exercise
     runs-on: ubuntu-latest
     if: |
-      !github.event.repository.is_template && github.run_number != 1
+      !github.event.repository.is_template
     env:
       ISSUE_URL: ${{ needs.find_exercise.outputs.issue-url }}
 


### PR DESCRIPTION
This pull request updates multiple GitHub Actions workflow files to refine the conditional execution of jobs. Specifically, it separates the condition `github.run_number != 1` into its own `if` block for the `find_exercise` job and removes it from the `if` condition of the `check_step_work` job.