### PR TITLE
fix: change permissions to read for contents in dependabot workflow

### DIFF
--- a/.github/workflows/4-dependabot-versions.yml
+++ b/.github/workflows/4-dependabot-versions.yml
@@ -8,7 +8,7 @@ on:
       - ".github/dependabot.yml"
 
 permissions:
-  contents: write
+  contents: read
   actions: write
   issues: write
 


### PR DESCRIPTION
This pull request includes a minor change to the `.github/workflows/4-dependabot-versions.yml` file. The change modifies the `permissions` section, updating the `contents` permission from `write` to `read`.