### PR TITLE
fix: update permissions to write for contents in dependabot workflow

### DIFF
--- a/.github/workflows/4-dependabot-versions.yml
+++ b/.github/workflows/4-dependabot-versions.yml
@@ -8,7 +8,7 @@ on:
       - ".github/dependabot.yml"
 
 permissions:
-  contents: read
+  contents: write
   actions: write
   issues: write
 
@@ -29,7 +29,7 @@ jobs:
     needs: find_exercise
     runs-on: ubuntu-latest
     if: |
-      !github.event.repository.is_template
+      github.event.repository.is_template == false
     env:
       ISSUE_URL: ${{ needs.find_exercise.outputs.issue-url }}
 


### PR DESCRIPTION
This pull request makes updates to the `.github/workflows/4-dependabot-versions.yml` file to adjust permissions and improve the conditional logic in the workflow. The most important changes include modifying repository content permissions and refining the conditional check for template repositories.